### PR TITLE
Let lodash and tslint versions float within major

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@eropple/nestjs-auth",
+  "name": "@hydrow/nestjs-auth",
   "version": "0.5.2",
   "description": "Comprehensive handling of authentication and authorization for NestJS.",
   "main": "dist",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "@types/cookie": "^0.3.2",
     "@types/express": "^4.16.1",
     "@types/jest": "^24.0.13",
-    "@types/lodash": "4.14.145",
+    "@types/lodash": "^4.14.145",
     "prettier": "^1.18.2",
     "rxjs": ">=6.4.0",
     "ts-jest": "^24.0.2",
-    "tslint": "5.20.1",
+    "tslint": "^5.20.1",
     "typescript": "^3.2.4"
   },
   "dependencies": {
@@ -43,7 +43,7 @@
     "bunyan": "^1.8.12",
     "bunyan-blackhole": "^1.1.1",
     "cookie": "^0.4.0",
-    "lodash": "4.17.15",
+    "lodash": "^4.17.15",
     "nanomatch": "^1.2.13",
     "reflect-metadata": "^0.1.13",
     "utility-types": "^3.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,10 +169,10 @@
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/lodash@4.14.145":
-  version "4.14.145"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.145.tgz#abcafe85788f1392c5d5a144142aaf8529ad6bb9"
-  integrity sha512-7lX5bZFO3YG3AG0XVIm5L1SB6wDLtuaJksTkTWrux3/XwCZgw3MPWZBt3Jgj0w98uqUXWVypT2msxo0A1t22lw==
+"@types/lodash@^4.14.145":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
 "@types/mime@*":
   version "2.0.1"
@@ -1226,10 +1226,10 @@ lodash@4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@^4.17.15:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 lru-queue@0.1:
   version "0.1.0"
@@ -1995,7 +1995,7 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslint@5.20.1:
+tslint@^5.20.1:
   version "5.20.1"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.1.tgz#e401e8aeda0152bc44dd07e614034f3f80c67b7d"
   integrity sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==


### PR DESCRIPTION
This removes a `yarn audit` warning about prototype pollution - the last warning we have in data-api-v2. It also has the benefit of moving us from the public @eropple to the private @hydrow which will make future edits to the library easier.